### PR TITLE
build: add minimalist travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+
+go:
+- "1.10"
+
+env:
+- DEP_VERSION="0.4.1"
+
+before_install:
+- curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+- chmod +x $GOPATH/bin/dep
+
+install:
+- dep ensure -v
+
+script:
+- go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Parser OpenAPI
+# Parser OpenAPI [![Build Status](https://travis-ci.org/alexjomin/openapi-parser.svg?branch=master)](https://travis-ci.org/alexjomin/openapi-parser)
 
 Parse openAPI from go comments in handlers and structs
 


### PR DESCRIPTION
Added a minimalist file to run `go test -v -race ./...` on Travis 