### PR TITLE
feat(support map): Add Map support on parsing

### DIFF
--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -66,21 +66,28 @@ func GetUser() {}
 //								$ref: "#/components/schemas/Pet"
 func PostFoo() {}
 
+// MapStringString type
+// @openapi:schema
+type MapStringString map[string]string
+
 // Pet struct
 // @openapi:schema
 type Pet struct {
-	ID              bson.ObjectId `json:"id"`
-	String          string        `json:"string,omitempty" validate:"required"`
-	Int             int           `json:"int,omitempty"`
-	PointerOfString *string       `json:"pointerOfString"`
-	SliceOfString   []string      `json:"sliceofString"`
-	SliceOfInt      []int         `json:"sliceofInt"`
-	Struct          Foo           `json:"struct"`
-	SliceOfStruct   []Foo         `json:"sliceOfStruct"`
-	PointerOfStruct *Foo          `json:"pointerOfStruct"`
-	Time            time.Time     `json:"time"`
-	PointerOfTime   *time.Time    `json:"pointerOfTime"`
-	EnumTest        string        `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
+	ID              bson.ObjectId     `json:"id"`
+	String          string            `json:"string,omitempty" validate:"required"`
+	Int             int               `json:"int,omitempty"`
+	PointerOfString *string           `json:"pointerOfString"`
+	SliceOfString   []string          `json:"sliceofString"`
+	SliceOfInt      []int             `json:"sliceofInt"`
+	Struct          Foo               `json:"struct"`
+	SliceOfStruct   []Foo             `json:"sliceOfStruct"`
+	PointerOfStruct *Foo              `json:"pointerOfStruct"`
+	Time            time.Time         `json:"time"`
+	PointerOfTime   *time.Time        `json:"pointerOfTime"`
+	EnumTest        string            `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
+	StrData         map[string]string `json:"strData"`
+	Children        map[string]Pet    `json:"children"`
+	IntData         map[string]int    `json:"IntData"`
 }
 
 // Foo struct

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -87,7 +87,7 @@ type schema struct {
 	Ref                  string            `yaml:"$ref,omitempty"`
 	Enum                 []string          `yaml:",omitempty"`
 	Properties           map[string]schema `yaml:",omitempty"`
-	AdditionalProperties bool              `yaml:"additionalProperties,omitempty"`
+	AdditionalProperties *schema           `yaml:"additionalProperties,omitempty"`
 	OneOf                []schema          `yaml:"oneOf,omitempty"`
 }
 
@@ -283,7 +283,7 @@ func (spec *openAPI) parseSchemas(f *ast.File) {
 
 					e := newEntity()
 					e.Type = "object"
-					e.AdditionalProperties = true
+					e.AdditionalProperties = &schema{}
 
 					// map[string]interface{}
 					if _, ok := mp.Value.(*ast.InterfaceType); ok {

--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -108,7 +108,17 @@ func parseNamedType(gofile *ast.File, expr ast.Expr) (*schema, error) {
 		t, _ := parseNamedType(gofile, ftpe.X)
 		return t, nil
 	case *ast.MapType:
-		return nil, fmt.Errorf("expr (%s) not yet unsupported", expr)
+		k, kerr := parseNamedType(gofile, ftpe.Key)
+		v, verr := parseNamedType(gofile, ftpe.Value)
+		if kerr != nil || verr != nil || k.Type != "string" {
+			// keys can only be of type string
+			return nil, fmt.Errorf("expr (%s) not yet unsupported", expr)
+		}
+
+		p.Type = "object"
+		p.AdditionalProperties = v
+
+		return &p, nil
 	case *ast.InterfaceType:
 		return nil, fmt.Errorf("expr (%s) not yet unsupported", expr)
 	default:


### PR DESCRIPTION
### Modification of the model
The [openapi spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#properties) says:
> **additionalProperties** - Value can be **boolean** or **object**. Inline or referenced schema MUST be of a **Schema Object** and not a standard JSON Schema.

It seems not possible in go to have this kind of "double type" but the [openapi spec](https://swagger.io/docs/specification/data-models/dictionaries/#free-form) also says that:
```yaml
type: object
additionalProperties: true
```
This is equivalent to:
```yaml
type: object
additionalProperties: {}
```

So I changed type of AdditionalProperties from `bool` to `&schema`.

### Modification of the parser#parseNamedType
implementing the `case *ast.MapType` to generate:
```yaml
type: object
additionalProperties:
  type: string # or other simple type like integer or boolean
```
or
```yaml
type: object
additionalProperties:
  $ref: '#/components/schemas/Pet' # or other complex type
```

Free-Form Objects (`interface{}`) still not be supported as Key or Value.

### Note
Keys of maps can only be of type string, throw an error in case of keys are of another type.
