### PR TITLE
Feat/add types

### DIFF
--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -88,6 +88,7 @@ type Pet struct {
 	StrData         map[string]string `json:"strData"`
 	Children        map[string]Pet    `json:"children"`
 	IntData         map[string]int    `json:"IntData"`
+	ByteData        []byte            `json:"ByteData"`
 }
 
 // Foo struct

--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -92,6 +92,11 @@ func parseNamedType(gofile *ast.File, expr ast.Expr) (*schema, error) {
 		return t, nil
 	case *ast.ArrayType: // slice type
 		cp, _ := parseNamedType(gofile, ftpe.Elt)
+		if cp.Format == "binary" {
+			p.Type = "string"
+			p.Format = "binary"
+			return &p, nil
+		}
 		p.Type = "array"
 		p.Items = map[string]string{}
 		if cp.Type != "" {
@@ -135,10 +140,15 @@ func parseIdentProperty(expr *ast.Ident) (t, format string, err error) {
 		t = "string"
 	case "int":
 		t = "integer"
+	case "int8":
+		t = "integer"
+		format = "int8"
 	case "int64":
 		t = "integer"
+		format = "int64"
 	case "int32":
 		t = "integer"
+		format = "int32"
 	case "time":
 		t = "string"
 		format = "date-time"
@@ -146,6 +156,9 @@ func parseIdentProperty(expr *ast.Ident) (t, format string, err error) {
 		t = "number"
 	case "bool":
 		t = "boolean"
+	case "byte":
+		t = "string"
+		format = "binary"
 	default:
 		t = expr.Name
 		err = fmt.Errorf("Can't set the type %s", expr.Name)

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -100,6 +100,11 @@ func TestParseNamedType(t *testing.T) {
 			expectedSchema: &schema{Type: "string", Format: "date-time"},
 		},
 		{
+			description:    "Should parse *ast.Ident with name byte",
+			expr:           &ast.Ident{Name: "byte"},
+			expectedSchema: &schema{Type: "string", Format: "binary"},
+		},
+		{
 			description:    "Should parse *ast.StarExpr and set Nullable",
 			expr:           &ast.StarExpr{X: &ast.Ident{Name: "time"}},
 			expectedSchema: &schema{Type: "string", Format: "date-time", Nullable: true},
@@ -110,6 +115,11 @@ func TestParseNamedType(t *testing.T) {
 			expectedSchema: &schema{Type: "array", Items: map[string]string{
 				"type": "string",
 			}},
+		},
+		{
+			description:    "Should parse *ast.ArrayType with byte type",
+			expr:           &ast.ArrayType{Elt: &ast.Ident{Name: "byte"}},
+			expectedSchema: &schema{Type: "string", Format: "binary"},
 		},
 		{
 			description: "Should parse *ast.ArrayType with unknown type",
@@ -422,14 +432,16 @@ func TestParseIdentProperty(t *testing.T) {
 			expectedType: "integer",
 		},
 		{
-			description:  "parse int64 ident type",
-			expr:         &ast.Ident{Name: "int64"},
-			expectedType: "integer",
+			description:    "parse int64 ident type",
+			expr:           &ast.Ident{Name: "int64"},
+			expectedType:   "integer",
+			expectedFormat: "int64",
 		},
 		{
-			description:  "parse int32 ident type",
-			expr:         &ast.Ident{Name: "int32"},
-			expectedType: "integer",
+			description:    "parse int32 ident type",
+			expr:           &ast.Ident{Name: "int32"},
+			expectedType:   "integer",
+			expectedFormat: "int32",
 		},
 		{
 			description:    "parse time ident type",


### PR DESCRIPTION
This PR adds `byte` and `[]byte` handling.
I followed the specs described here: https://swagger.io/specification/#dataTypes

It's a bit weird for `[]byte` but I didn't see another way of doing it easily.