### PR TITLE
Add support for security scheme

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alexjomin/openapi-parser/docparser"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 var (

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -25,6 +25,7 @@ type openAPI struct {
 	Paths      map[string]path
 	Tags       []tag `yaml:"tags,omitempty"`
 	Components Components
+	Security   []map[string][]string `yaml:"security,omitempty"`
 }
 
 type server struct {
@@ -47,8 +48,9 @@ type Components struct {
 }
 
 type securitySchemes struct {
-	Type  string
-	Flows map[string]flow
+	Type   string
+	Flows  map[string]flow
+	Scheme string `yaml:"scheme,omitempty"`
 }
 
 type flow struct {


### PR DESCRIPTION
This PR adds support for `security` and `scheme` in `components.securitySchemes`

This is necessary to use [openapi-generator](https://openapi-generator.tech/).