### PR TITLE
feat: implements parsing for array of arrays

### DIFF
--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -73,22 +73,23 @@ type MapStringString map[string]string
 // Pet struct
 // @openapi:schema
 type Pet struct {
-	ID              bson.ObjectId     `json:"id"`
-	String          string            `json:"string,omitempty" validate:"required"`
-	Int             int               `json:"int,omitempty"`
-	PointerOfString *string           `json:"pointerOfString"`
-	SliceOfString   []string          `json:"sliceofString"`
-	SliceOfInt      []int             `json:"sliceofInt"`
-	Struct          Foo               `json:"struct"`
-	SliceOfStruct   []Foo             `json:"sliceOfStruct"`
-	PointerOfStruct *Foo              `json:"pointerOfStruct"`
-	Time            time.Time         `json:"time"`
-	PointerOfTime   *time.Time        `json:"pointerOfTime"`
-	EnumTest        string            `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
-	StrData         map[string]string `json:"strData"`
-	Children        map[string]Pet    `json:"children"`
-	IntData         map[string]int    `json:"IntData"`
-	ByteData        []byte            `json:"ByteData"`
+	ID                  bson.ObjectId     `json:"id"`
+	String              string            `json:"string,omitempty" validate:"required"`
+	Int                 int               `json:"int,omitempty"`
+	PointerOfString     *string           `json:"pointerOfString"`
+	SliceOfString       []string          `json:"sliceofString"`
+	SliceOfInt          []int             `json:"sliceofInt"`
+	SliceOfSliceOfFloat [][]float64       `json:"sliceofSliceofFloat"`
+	Struct              Foo               `json:"struct"`
+	SliceOfStruct       []Foo             `json:"sliceOfStruct"`
+	PointerOfStruct     *Foo              `json:"pointerOfStruct"`
+	Time                time.Time         `json:"time"`
+	PointerOfTime       *time.Time        `json:"pointerOfTime"`
+	EnumTest            string            `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
+	StrData             map[string]string `json:"strData"`
+	Children            map[string]Pet    `json:"children"`
+	IntData             map[string]int    `json:"IntData"`
+	ByteData            []byte            `json:"ByteData"`
 }
 
 // Foo struct

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -76,7 +76,7 @@ type tag struct {
 func newEntity() schema {
 	e := schema{}
 	e.Properties = make(map[string]schema)
-	e.Items = make(map[string]string)
+	e.Items = make(map[string]interface{})
 	return e
 }
 
@@ -85,16 +85,16 @@ type composedSchema struct {
 }
 
 type schema struct {
-	Nullable             bool              `yaml:"nullable,omitempty"`
-	Required             []string          `yaml:"required,omitempty"`
-	Type                 string            `yaml:",omitempty"`
-	Items                map[string]string `yaml:",omitempty"`
-	Format               string            `yaml:"format,omitempty"`
-	Ref                  string            `yaml:"$ref,omitempty"`
-	Enum                 []string          `yaml:",omitempty"`
-	Properties           map[string]schema `yaml:",omitempty"`
-	AdditionalProperties *schema           `yaml:"additionalProperties,omitempty"`
-	OneOf                []schema          `yaml:"oneOf,omitempty"`
+	Nullable             bool                   `yaml:"nullable,omitempty"`
+	Required             []string               `yaml:"required,omitempty"`
+	Type                 string                 `yaml:",omitempty"`
+	Items                map[string]interface{} `yaml:",omitempty"`
+	Format               string                 `yaml:"format,omitempty"`
+	Ref                  string                 `yaml:"$ref,omitempty"`
+	Enum                 []string               `yaml:",omitempty"`
+	Properties           map[string]schema      `yaml:",omitempty"`
+	AdditionalProperties *schema                `yaml:"additionalProperties,omitempty"`
+	OneOf                []schema               `yaml:"oneOf,omitempty"`
 }
 
 type items struct {

--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -98,9 +98,12 @@ func parseNamedType(gofile *ast.File, expr ast.Expr) (*schema, error) {
 			return &p, nil
 		}
 		p.Type = "array"
-		p.Items = map[string]string{}
+		p.Items = map[string]interface{}{}
 		if cp.Type != "" {
 			p.Items["type"] = cp.Type
+			if len(cp.Items) != 0 {
+				p.Items["items"] = cp.Items
+			}
 		}
 		if cp.Ref != "" {
 			p.Items["$ref"] = cp.Ref

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -110,9 +110,9 @@ func TestParseNamedType(t *testing.T) {
 			expectedSchema: &schema{Type: "string", Format: "date-time", Nullable: true},
 		},
 		{
-			description: "Should parse *ast.ArrayType with know type",
+			description: "Should parse *ast.ArrayType with known type",
 			expr:        &ast.ArrayType{Elt: &ast.Ident{Name: "time"}},
-			expectedSchema: &schema{Type: "array", Items: map[string]string{
+			expectedSchema: &schema{Type: "array", Items: map[string]interface{}{
 				"type": "string",
 			}},
 		},
@@ -124,8 +124,18 @@ func TestParseNamedType(t *testing.T) {
 		{
 			description: "Should parse *ast.ArrayType with unknown type",
 			expr:        &ast.ArrayType{Elt: &ast.Ident{Name: "unknown"}},
-			expectedSchema: &schema{Type: "array", Items: map[string]string{
+			expectedSchema: &schema{Type: "array", Items: map[string]interface{}{
 				"$ref": "#/components/schemas/unknown",
+			}},
+		},
+		{
+			description: "Should parse *ast.ArrayType with array type",
+			expr:        &ast.ArrayType{Elt: &ast.ArrayType{Elt: &ast.Ident{Name: "float64"}}},
+			expectedSchema: &schema{Type: "array", Items: map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "number",
+				},
 			}},
 		},
 		{
@@ -195,14 +205,14 @@ func TestParseNamedType(t *testing.T) {
 		{
 			description: "Should parse correctly a selector of an array of pointer of unknown type",
 			expr:        &ast.SelectorExpr{X: &ast.ArrayType{Elt: &ast.StarExpr{X: &ast.Ident{Name: "unknown"}}}},
-			expectedSchema: &schema{Type: "array", Items: map[string]string{
+			expectedSchema: &schema{Type: "array", Items: map[string]interface{}{
 				"$ref": "#/components/schemas/unknown",
 			}},
 		},
 		{
 			description: "Should parse correctly a selector of an array of pointer of time type",
 			expr:        &ast.SelectorExpr{X: &ast.ArrayType{Elt: &ast.StarExpr{X: &ast.Ident{Name: "time"}}}},
-			expectedSchema: &schema{Type: "array", Items: map[string]string{
+			expectedSchema: &schema{Type: "array", Items: map[string]interface{}{
 				"type": "string",
 			}},
 		},


### PR DESCRIPTION
This PR implements parsing for arrays of arrays e.g. `[][]float64` or `[][][]string`

For this I changed the `schema.Items` type from `map[string]string` to `map[string]interface{}`.

This allows us to pass the items of the child array to the items of the parent array.