### PR TITLE
fix: custom type should appear as their parent type if possible

### DIFF
--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -167,6 +167,14 @@ func parseIdentProperty(expr *ast.Ident) (t, format string, err error) {
 		t = "string"
 		format = "binary"
 	default:
+		if expr.Obj != nil {
+			// maybe a custom type
+			if typ, ok := expr.Obj.Decl.(*ast.TypeSpec); ok {
+				if ident, ok := typ.Type.(*ast.Ident); ok {
+					return parseIdentProperty(ident)
+				}
+			}
+		}
 		t = expr.Name
 		err = fmt.Errorf("Can't set the type %s", expr.Name)
 	}


### PR DESCRIPTION
For custom types like:
```go
type JobState string
```

For now the generated field looks like:
```yaml
state:
          $ref: '#/components/schemas/JobState'
```

This PR make the field looks like:
```yaml
state:
          type: string
```