### PR TITLE
Rework spec composition to make sure to use custom names for types, also adds interface{} and external package handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- "1.13"
+- "1.14"
 
 script:
 - go test -v -race ./...

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -67,6 +67,9 @@ var mergeCmd = &cobra.Command{
 			}
 
 			for k, v := range spec.Components.Schemas {
+				if k == "AnyValue" {
+					continue
+				}
 				s, ok := main.Components.Schemas[k]
 				if ok {
 					result := reflect.DeepEqual(s, v)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -67,9 +67,6 @@ var mergeCmd = &cobra.Command{
 			}
 
 			for k, v := range spec.Components.Schemas {
-				if k == "AnyValue" {
-					continue
-				}
 				s, ok := main.Components.Schemas[k]
 				if ok {
 					result := reflect.DeepEqual(s, v)

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -82,6 +82,14 @@ var mergeCmd = &cobra.Command{
 				logrus.WithField("schema", k).Info("Adding Schema")
 			}
 
+			registeredServers := make(map[string]bool)
+			for _, server := range spec.Servers {
+				if _, found := registeredServers[server.URL]; found {
+					continue
+				}
+				main.Servers = append(main.Servers, server)
+				registeredServers[server.URL] = true
+			}
 		}
 
 		d, err := yaml.Marshal(&main)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var (
 	outputPath   string
 	inputPath    string
 	parseVendors []string
+	vendorsPath  string
 )
 
 // RootCmd represents the root command
@@ -24,7 +25,7 @@ var RootCmd = &cobra.Command{
 	Long:  `Parse comments in code to generate an OpenAPI documentation`,
 	Run: func(cmd *cobra.Command, args []string) {
 		spec := docparser.NewOpenAPI()
-		spec.Parse(inputPath, parseVendors)
+		spec.Parse(inputPath, parseVendors, vendorsPath)
 		d, err := yaml.Marshal(&spec)
 		if err != nil {
 			log.Fatalf("error: %v", err)
@@ -46,4 +47,5 @@ func init() {
 	RootCmd.Flags().StringVar(&outputPath, "output", "openapi.yaml", "The output file")
 	RootCmd.Flags().StringVar(&inputPath, "path", ".", "The Folder to parse")
 	RootCmd.Flags().StringArrayVar(&parseVendors, "parse-vendors", []string{}, "Give the vendor to parse")
+	RootCmd.Flags().StringVar(&vendorsPath, "vendors-path", "vendor", "Give the vendor path")
 }

--- a/docparser/datatest/otherpackage/data.go
+++ b/docparser/datatest/otherpackage/data.go
@@ -1,0 +1,6 @@
+package otherpackage
+
+// @openapi:schema:WeirdCustomName
+type Data struct {
+	SomeString string `json:"some_string"`
+}

--- a/docparser/datatest/otherpackage/data.go
+++ b/docparser/datatest/otherpackage/data.go
@@ -4,3 +4,7 @@ package otherpackage
 type Data struct {
 	SomeString string `json:"some_string"`
 }
+
+// CustomString
+// @openapi:schema
+type CustomString string

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"time"
 
-	"github.com/alexjomin/openapi-parser/docparser/datatest/otherpackage"
-
 	"gopkg.in/mgo.v2/bson"
+
+	"github.com/alexjomin/openapi-parser/docparser/datatest/otherpackage"
 )
 
 // GetUser returns a user corresponding to specified id
@@ -72,29 +73,32 @@ func PostFoo() {}
 // @openapi:schema
 type MapStringString map[string]string
 
+// @openapi:schema
+type WeirdInt int
+
 // Pet struct
 // @openapi:schema
 type Pet struct {
-	ID                          bson.ObjectId     `json:"id"`
-	String                      string            `json:"string,omitempty" validate:"required"`
-	Int                         int               `json:"int,omitempty"`
-	PointerOfString             *string           `json:"pointerOfString"`
-	SliceOfString               []string          `json:"sliceofString"`
-	SliceOfInt                  []int             `json:"sliceofInt"`
-	SliceOfSliceOfFloat         [][]float64       `json:"sliceofSliceofFloat"`
-	Struct                      Foo               `json:"struct"`
-	StructWithCorrectSchemaName Foo2              `json:"struct_correct_name"`
-	ExternalData                otherpackage.Data `json:"external_data"`
-	SliceOfStruct               []Foo             `json:"sliceOfStruct"`
-	PointerOfStruct             *Foo              `json:"pointerOfStruct"`
-	Time                        time.Time         `json:"time"`
-	PointerOfTime               *time.Time        `json:"pointerOfTime"`
-	EnumTest                    string            `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
-	StrData                     map[string]string `json:"strData"`
-	Children                    map[string]Pet    `json:"children"`
-	IntData                     map[string]int    `json:"IntData"`
-	ByteData                    []byte            `json:"ByteData"`
-	Interface                   interface{}       `json:"interface"`
+	ID                  bson.ObjectId             `json:"id"`
+	String              string                    `json:"string,omitempty" validate:"required"`
+	Int                 int                       `json:"int,omitempty"`
+	PointerOfString     *string                   `json:"pointerOfString"`
+	SliceOfString       []string                  `json:"sliceofString"`
+	SliceOfInt          []int                     `json:"sliceofInt"`
+	SliceOfSliceOfFloat [][]float64               `json:"sliceofSliceofFloat"`
+	Struct              Foo                       `json:"struct"`
+	SliceOfStruct       []Foo                     `json:"sliceOfStruct"`
+	PointerOfStruct     *Foo                      `json:"pointerOfStruct"`
+	Time                time.Time                 `json:"time"`
+	PointerOfTime       *time.Time                `json:"pointerOfTime"`
+	EnumTest            string                    `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
+	StrData             map[string]string         `json:"strData"`
+	Children            map[string]Pet            `json:"children"`
+	IntData             map[string]int            `json:"IntData"`
+	ByteData            []byte                    `json:"ByteData"`
+	JSONData            json.RawMessage           `json:"json_data"`
+	CustomString        otherpackage.CustomString `json:"custom_string"`
+	Test                Test                      `json:"test"`
 }
 
 // Dog struct
@@ -121,6 +125,10 @@ type Foo2 struct {
 // Signals struct
 // @openapi:schema
 type Signals []Foo
+
+// Test struct
+// @openapi:schema
+type Test int
 
 // @openapi:info
 //  version: 0.0.1

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"time"
 
+	"github.com/alexjomin/openapi-parser/docparser/datatest/otherpackage"
+
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -73,23 +75,35 @@ type MapStringString map[string]string
 // Pet struct
 // @openapi:schema
 type Pet struct {
-	ID                  bson.ObjectId     `json:"id"`
-	String              string            `json:"string,omitempty" validate:"required"`
-	Int                 int               `json:"int,omitempty"`
-	PointerOfString     *string           `json:"pointerOfString"`
-	SliceOfString       []string          `json:"sliceofString"`
-	SliceOfInt          []int             `json:"sliceofInt"`
-	SliceOfSliceOfFloat [][]float64       `json:"sliceofSliceofFloat"`
-	Struct              Foo               `json:"struct"`
-	SliceOfStruct       []Foo             `json:"sliceOfStruct"`
-	PointerOfStruct     *Foo              `json:"pointerOfStruct"`
-	Time                time.Time         `json:"time"`
-	PointerOfTime       *time.Time        `json:"pointerOfTime"`
-	EnumTest            string            `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
-	StrData             map[string]string `json:"strData"`
-	Children            map[string]Pet    `json:"children"`
-	IntData             map[string]int    `json:"IntData"`
-	ByteData            []byte            `json:"ByteData"`
+	ID                          bson.ObjectId     `json:"id"`
+	String                      string            `json:"string,omitempty" validate:"required"`
+	Int                         int               `json:"int,omitempty"`
+	PointerOfString             *string           `json:"pointerOfString"`
+	SliceOfString               []string          `json:"sliceofString"`
+	SliceOfInt                  []int             `json:"sliceofInt"`
+	SliceOfSliceOfFloat         [][]float64       `json:"sliceofSliceofFloat"`
+	Struct                      Foo               `json:"struct"`
+	StructWithCorrectSchemaName Foo2              `json:"struct_correct_name"`
+	ExternalData                otherpackage.Data `json:"external_data"`
+	SliceOfStruct               []Foo             `json:"sliceOfStruct"`
+	PointerOfStruct             *Foo              `json:"pointerOfStruct"`
+	Time                        time.Time         `json:"time"`
+	PointerOfTime               *time.Time        `json:"pointerOfTime"`
+	EnumTest                    string            `json:"enumTest" validate:"enum=UNKNOWN MALE FEMALE"`
+	StrData                     map[string]string `json:"strData"`
+	Children                    map[string]Pet    `json:"children"`
+	IntData                     map[string]int    `json:"IntData"`
+	ByteData                    []byte            `json:"ByteData"`
+	Interface                   interface{}       `json:"interface"`
+}
+
+// Dog struct
+// @openapi:schema
+type Dog struct {
+	Pet
+	otherpackage.Data
+
+	Name string `json:"name"`
 }
 
 // Foo struct

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -34,16 +34,26 @@ import (
 //							type: string
 //		parameters:
 //			- in: path
-//				name: deviceId
-//				schema:
-//					type: integer
-//					enum: [3, 4]
-//				required: true
-//				description: Numeric ID of the user to get
+//			  name: deviceId
+//			  schema:
+//			  	type: integer
+//			  	enum: [3, 4]
+//			  required: true
+//			  description: Numeric ID of the user to get
 //		security:
 //			- petstore_auth:
 //				- write:pets
 //				- read:pets
+//		servers:
+//        - url: "https://{environment}.hello.com"
+//          description: "what up"
+//          variables:
+//            environment:
+//              default: api    # Production server
+//              enum:
+//                - api         # Production server
+//                - api.dev     # Development server
+//                - api.staging # Staging server
 func GetUser() {}
 
 // PostFoo returns a user corresponding to specified id

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"time"
 
 	"gopkg.in/mgo.v2/bson"
@@ -90,6 +91,7 @@ type Pet struct {
 	Children            map[string]Pet    `json:"children"`
 	IntData             map[string]int    `json:"IntData"`
 	ByteData            []byte            `json:"ByteData"`
+	JSONData            json.RawMessage   `json:"json_data"`
 }
 
 // Foo struct

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -176,6 +176,7 @@ type action struct {
 	RequestBody requestBody           `yaml:"requestBody,omitempty"`
 	Security    []map[string][]string `yaml:",omitempty"`
 	Headers     map[string]header     `yaml:",omitempty"`
+	Servers     []map[string]string   `yaml:",omitempty"`
 }
 
 type parameter struct {

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -244,10 +244,10 @@ func validatePath(path string, parseVendors []string) bool {
 	return true
 }
 
-func (spec *openAPI) Parse(path string, parseVendors []string) {
+func (spec *openAPI) Parse(path string, parseVendors []string, vendorsPath string) {
 	// fset := token.NewFileSet() // positions are relative to fset
 
-	_ = filepath.Walk(path, func(path string, f os.FileInfo, err error) error {
+	walker := func(path string, f os.FileInfo, err error) error {
 		if validatePath(path, parseVendors) {
 			astFile, _ := parseFile(path)
 			spec.parseInfos(astFile)
@@ -255,7 +255,10 @@ func (spec *openAPI) Parse(path string, parseVendors []string) {
 			spec.parsePaths(astFile)
 		}
 		return nil
-	})
+	}
+
+	_ = filepath.Walk(path, walker)
+	_ = filepath.Walk(vendorsPath, walker)
 	spec.composeSpecSchemas()
 }
 

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -16,6 +16,12 @@ var (
 	rexexpSchema = regexp.MustCompile(`@openapi:schema:?(\w+)?:?(?:\[([\w,]+)\])?`)
 	regexpInfo   = regexp.MustCompile("@openapi:info\n([^@]*)$")
 	tab          = regexp.MustCompile(`\t`)
+
+	registeredSchemas = map[string]interface{}{
+		"AnyValue": map[string]string{
+			"description": "Can be anything: string, number, array, object, etc., including `null`",
+		},
+	}
 )
 
 type openAPI struct {
@@ -39,6 +45,7 @@ func NewOpenAPI() openAPI {
 	spec.Paths = make(map[string]path)
 	spec.Components = Components{}
 	spec.Components.Schemas = make(map[string]interface{})
+
 	return spec
 }
 
@@ -50,7 +57,7 @@ type Components struct {
 type securitySchemes struct {
 	Type   string
 	Flows  map[string]flow `yaml:"flows,omitempty"`
-	Scheme string `yaml:"scheme,omitempty"`
+	Scheme string          `yaml:"scheme,omitempty"`
 }
 
 type flow struct {
@@ -75,16 +82,50 @@ type tag struct {
 
 func newEntity() schema {
 	e := schema{}
-	e.Properties = make(map[string]schema)
+	e.Properties = make(map[string]*schema)
 	e.Items = make(map[string]interface{})
 	return e
 }
 
+type metaSchema interface {
+	RealName() string
+	CustomName() string
+	SetCustomName(string)
+}
+
+type metadata struct {
+	RealName   string `yaml:"-"`
+	CustomName string `yaml:"-"`
+}
+
 type composedSchema struct {
-	AllOf []*schema `yaml:"allOf"`
+	metadata `yaml:"-"`
+	AllOf    []*schema `yaml:"allOf"`
+}
+
+func (c *composedSchema) RealName() string {
+	if c == nil {
+		return ""
+	}
+	return c.metadata.RealName
+}
+
+func (c *composedSchema) CustomName() string {
+	if c == nil {
+		return ""
+	}
+	return c.metadata.CustomName
+}
+
+func (c *composedSchema) SetCustomName(customName string) {
+	if c == nil {
+		return
+	}
+	c.metadata.CustomName = customName
 }
 
 type schema struct {
+	metadata             `yaml:"-"`
 	Nullable             bool                   `yaml:"nullable,omitempty"`
 	Required             []string               `yaml:"required,omitempty"`
 	Type                 string                 `yaml:",omitempty"`
@@ -92,9 +133,30 @@ type schema struct {
 	Format               string                 `yaml:"format,omitempty"`
 	Ref                  string                 `yaml:"$ref,omitempty"`
 	Enum                 []string               `yaml:",omitempty"`
-	Properties           map[string]schema      `yaml:",omitempty"`
+	Properties           map[string]*schema     `yaml:",omitempty"`
 	AdditionalProperties *schema                `yaml:"additionalProperties,omitempty"`
 	OneOf                []schema               `yaml:"oneOf,omitempty"`
+}
+
+func (s *schema) RealName() string {
+	if s == nil {
+		return ""
+	}
+	return s.metadata.RealName
+}
+
+func (s *schema) CustomName() string {
+	if s == nil {
+		return ""
+	}
+	return s.metadata.CustomName
+}
+
+func (s *schema) SetCustomName(customName string) {
+	if s == nil {
+		return
+	}
+	s.metadata.CustomName = customName
 }
 
 type items struct {
@@ -185,7 +247,7 @@ func (spec *openAPI) Parse(path string, parseVendors []string) {
 		}
 		return nil
 	})
-
+	spec.composeSpecSchemas()
 }
 
 func (spec *openAPI) parsePaths(f *ast.File) {
@@ -242,6 +304,135 @@ func (spec *openAPI) parsePaths(f *ast.File) {
 	}
 }
 
+func replaceSchemaNameToCustom(s *schema) {
+	if s == nil {
+		return
+	}
+
+	for _, property := range s.Properties {
+		replaceSchemaNameToCustom(property)
+	}
+	replaceSchemaNameToCustom(s.AdditionalProperties)
+
+	refSplit := strings.Split(s.Ref, "/")
+	if len(refSplit) != 4 {
+		return
+	}
+	if replacementSchema, found := registeredSchemas[refSplit[3]]; found {
+		meta, ok := replacementSchema.(metaSchema)
+		if !ok {
+			return
+		}
+		refSplit[3] = meta.CustomName()
+	}
+	s.Ref = strings.Join(refSplit, "/")
+}
+
+func (spec *openAPI) composeSpecSchemas() {
+	for realName, registeredSchema := range registeredSchemas {
+		if realName == "AnyValue" {
+			spec.Components.Schemas[realName] = registeredSchema
+			continue
+		}
+
+		meta, ok := registeredSchema.(metaSchema)
+		if !ok {
+			continue
+		}
+
+		if composed, ok := registeredSchema.(*composedSchema); ok {
+			for _, s := range composed.AllOf {
+				replaceSchemaNameToCustom(s)
+			}
+		} else if normal, ok := registeredSchema.(*schema); ok {
+			replaceSchemaNameToCustom(normal)
+		}
+
+		name := realName
+		if meta.CustomName() != "" {
+			name = meta.CustomName()
+		}
+		spec.Components.Schemas[name] = registeredSchema
+	}
+}
+
+func (spec *openAPI) parseMaps(mp *ast.MapType) *schema {
+	// only map[string]
+	if i, ok := mp.Key.(*ast.Ident); ok {
+		t, _, _ := parseIdentProperty(i)
+		if t != "string" {
+			return nil
+		}
+	}
+
+	e := newEntity()
+	e.Type = "object"
+	e.AdditionalProperties = &schema{}
+
+	// map[string]interface{}
+	if _, ok := mp.Value.(*ast.InterfaceType); ok {
+		return &e
+	}
+
+	return nil
+}
+
+func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) interface{} {
+	var cs *composedSchema
+	e := newEntity()
+	e.Type = "object"
+
+	for _, fld := range tpe.Fields.List {
+		if len(fld.Names) > 0 && fld.Names[0] != nil && fld.Names[0].IsExported() {
+			j, err := parseJSONTag(fld)
+			if j.ignore {
+				continue
+			}
+			p, err := parseNamedType(f, fld.Type, nil)
+
+			if j.required {
+				e.Required = append(e.Required, j.name)
+			}
+
+			if err != nil {
+				logrus.WithError(err).WithField("field", fld.Names[0]).Error("Can't parse the type of field in struct")
+				continue
+			}
+
+			if len(j.enum) > 0 {
+				p.Enum = j.enum
+			}
+
+			if p != nil {
+				e.Properties[j.name] = p
+			}
+
+		} else {
+			// composition
+			if cs == nil {
+				cs = &composedSchema{
+					AllOf: make([]*schema, 0),
+				}
+			}
+
+			p, err := parseNamedType(f, fld.Type, nil)
+			if err != nil {
+				logrus.WithError(err).WithField("field", fld.Type).Error("Can't parse the type of composed field in struct")
+				continue
+			}
+
+			cs.AllOf = append(cs.AllOf, p)
+		}
+	}
+
+	if cs == nil {
+		return &e
+	} else {
+		cs.AllOf = append(cs.AllOf, &e)
+		return cs
+	}
+}
+
 func (spec *openAPI) parseSchemas(f *ast.File) {
 	for _, decl := range f.Decls {
 		gd, ok := decl.(*ast.GenDecl)
@@ -256,8 +447,9 @@ func (spec *openAPI) parseSchemas(f *ast.File) {
 			// If the node is a Type
 			if ts, ok := spc.(*ast.TypeSpec); ok {
 
-				entityName := ts.Name.Name
-				// fmt.Printf("type : %T %s\n", ts.Type, entityName)
+				var entity interface{}
+				realName := ts.Name.Name
+				entityName := realName
 
 				// Looking for openapi entity
 				a := rexexpSchema.FindSubmatch([]byte(t))
@@ -272,121 +464,46 @@ func (spec *openAPI) parseSchemas(f *ast.File) {
 					}
 				}
 
-				// array type
-				if ar, ok := ts.Type.(*ast.ArrayType); ok {
-					if i, ok := ar.Elt.(*ast.Ident); ok {
-						e := newEntity()
-						e.Type = "array"
-						t, _, _ := parseIdentProperty(i)
-						e.Items["type"] = t
-						logrus.
-							WithField("name", entityName).
-							Info("Parsing Schema")
-					}
-				}
-
 				// MapType
 				if mp, ok := ts.Type.(*ast.MapType); ok {
-
-					// only map[string]
-					if i, ok := mp.Key.(*ast.Ident); ok {
-						t, _, _ := parseIdentProperty(i)
-						if t != "string" {
-							continue
-						}
-					}
-
-					e := newEntity()
-					e.Type = "object"
-					e.AdditionalProperties = &schema{}
-
-					// map[string]interface{}
-					if _, ok := mp.Value.(*ast.InterfaceType); ok {
-						spec.Components.Schemas[entityName] = e
-						logrus.
-							WithField("name", entityName).
-							Info("Parsing Schema")
-					}
+					entity = spec.parseMaps(mp)
+					logrus.
+						WithField("name", entityName).
+						Info("Parsing Schema")
 				}
 
 				// StructType
 				if tpe, ok := ts.Type.(*ast.StructType); ok {
-					var cs *composedSchema
-					e := newEntity()
-					e.Type = "object"
-
+					entity = spec.parseStructs(f, tpe)
+					mtd, ok := entity.(metaSchema)
+					if ok {
+						mtd.SetCustomName(entityName)
+					}
 					logrus.
 						WithField("name", entityName).
 						Info("Parsing Schema")
-
-					for _, fld := range tpe.Fields.List {
-						if len(fld.Names) > 0 && fld.Names[0] != nil && fld.Names[0].IsExported() {
-							j, err := parseJSONTag(fld)
-							if j.ignore {
-								continue
-							}
-							p, err := parseNamedType(f, fld.Type)
-
-							if j.required {
-								e.Required = append(e.Required, j.name)
-							}
-
-							if err != nil {
-								logrus.WithError(err).WithField("field", fld.Names[0]).Error("Can't parse the type of field in struct")
-								continue
-							}
-
-							if len(j.enum) > 0 {
-								p.Enum = j.enum
-							}
-
-							if p != nil {
-								e.Properties[j.name] = *p
-							}
-
-						} else {
-							// composition
-							if cs == nil {
-								cs = &composedSchema{
-									AllOf: make([]*schema, 0),
-								}
-							}
-
-							p, err := parseNamedType(f, fld.Type)
-							if err != nil {
-								logrus.WithError(err).WithField("field", fld.Type).Error("Can't parse the type of composed field in struct")
-								continue
-							}
-
-							cs.AllOf = append(cs.AllOf, p)
-						}
-					}
-
-					if cs == nil {
-						spec.Components.Schemas[entityName] = e
-					} else {
-						cs.AllOf = append(cs.AllOf, &e)
-						spec.Components.Schemas[entityName] = cs
-					}
 				}
 
 				// ArrayType
 				if tpa, ok := ts.Type.(*ast.ArrayType); ok {
-					entity := newEntity()
-					p, err := parseNamedType(f, tpa.Elt)
+					e := newEntity()
+					p, err := parseNamedType(f, tpa.Elt, nil)
 					if err != nil {
 						logrus.WithError(err).Error("Can't parse the type of field in struct")
 						continue
 					}
 
-					entity.Type = "array"
+					e.Type = "array"
 					if p.Ref != "" {
-						entity.Items["$ref"] = p.Ref
+						e.Items["$ref"] = p.Ref
 					} else {
-						entity.Items["type"] = p.Type
+						e.Items["type"] = p.Type
 					}
+					entity = &e
+				}
 
-					spec.Components.Schemas[entityName] = entity
+				if entity != nil {
+					registeredSchemas[realName] = entity
 				}
 			}
 		}

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -32,6 +32,7 @@ type openAPI struct {
 	Tags       []tag `yaml:"tags,omitempty"`
 	Components Components
 	Security   []map[string][]string `yaml:"security,omitempty"`
+	XGroupTags []interface{}         `yaml:"x-tagGroups"`
 }
 
 type server struct {

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -36,8 +36,15 @@ type openAPI struct {
 }
 
 type server struct {
-	URL         string `yaml:"url"`
-	Description string `yame:"description"`
+	URL         string                    `yaml:"url"`
+	Description string                    `yaml:"description"`
+	Variables   map[string]serverVariable `yaml:",omitempty"`
+}
+
+type serverVariable struct {
+	Default     string
+	Enum        []string
+	Description string
 }
 
 func NewOpenAPI() openAPI {

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -176,7 +176,7 @@ type action struct {
 	RequestBody requestBody           `yaml:"requestBody,omitempty"`
 	Security    []map[string][]string `yaml:",omitempty"`
 	Headers     map[string]header     `yaml:",omitempty"`
-	Servers     []map[string]string   `yaml:",omitempty"`
+	Servers     []server              `yaml:",omitempty"`
 }
 
 type parameter struct {

--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -163,7 +163,7 @@ func parseIdentProperty(expr *ast.Ident) (t, format string, err error) {
 		t = "number"
 	case "bool":
 		t = "boolean"
-	case "byte":
+	case "byte", "json":
 		t = "string"
 		format = "binary"
 	default:

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -192,6 +192,11 @@ func TestParseNamedType(t *testing.T) {
 			expectedError: "expr (&{%!s(token.Pos=0) Object Pet}) not yet unsupported",
 		},
 		{
+			description:    "Should parse correctly a json.RawMessage",
+			expr:           &ast.Ident{Name: "json"},
+			expectedSchema: &schema{Type: "string", Format: "binary"},
+		},
+		{
 			description:   "Should throw error when parse *ast.InterfaceType",
 			expr:          &ast.InterfaceType{},
 			expectedError: "expr (&{%!s(token.Pos=0) %!s(*ast.FieldList=<nil>) %!s(bool=false)}) not yet unsupported",

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -152,12 +152,17 @@ func TestParseNamedType(t *testing.T) {
 			expectedError: "expr (&{%!s(token.Pos=0) <nil> <nil>}) not yet unsupported",
 		},
 		{
-			description: "Should throw error when parse *ast.MapType[string]interface{}",
+			description: "Should parse *ast.MapType[string]interface{}",
 			expr: &ast.MapType{
 				Key:   &ast.Ident{Name: "string"},
 				Value: &ast.InterfaceType{},
 			},
-			expectedError: "expr (&{%!s(token.Pos=0) string %!s(*ast.InterfaceType=&{0 <nil> false})}) not yet unsupported",
+			expectedSchema: &schema{
+				Type: "object",
+				AdditionalProperties: &schema{
+					Ref: "#/components/schemas/AnyValue",
+				},
+			},
 		},
 		{
 			description: "Should parse *ast.MapType[string]string",
@@ -192,9 +197,11 @@ func TestParseNamedType(t *testing.T) {
 			expectedError: "expr (&{%!s(token.Pos=0) Object Pet}) not yet unsupported",
 		},
 		{
-			description:   "Should throw error when parse *ast.InterfaceType",
-			expr:          &ast.InterfaceType{},
-			expectedError: "expr (&{%!s(token.Pos=0) %!s(*ast.FieldList=<nil>) %!s(bool=false)}) not yet unsupported",
+			description: "Should parse Interface type",
+			expr:        &ast.InterfaceType{},
+			expectedSchema: &schema{
+				Ref: "#/components/schemas/AnyValue",
+			},
 		},
 		{
 			description:    "Should parse *ast.SelectorExpr",
@@ -224,7 +231,7 @@ func TestParseNamedType(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			schema, err := parseNamedType(tc.gofile, tc.expr)
+			schema, err := parseNamedType(tc.gofile, tc.expr, nil)
 			if len(tc.expectedError) > 0 {
 				if (err != nil) && (err.Error() != tc.expectedError) {
 					t.Errorf("got error: %v, wantErr: %v", err, tc.expectedError)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -65,6 +65,8 @@ components:
     AnyValue:
       description: 'Can be anything: string, number, array, object, etc., including
         `null`'
+    CustomString:
+      type: string
     Dog:
       allOf:
       - $ref: '#/components/schemas/Pet'
@@ -100,20 +102,21 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/Pet'
+        custom_string:
+          $ref: '#/components/schemas/CustomString'
         enumTest:
           type: string
           enum:
           - UNKNOWN
           - MALE
           - FEMALE
-        external_data:
-          $ref: '#/components/schemas/WeirdCustomName'
         id:
           type: string
         int:
           type: integer
-        interface:
-          $ref: '#/components/schemas/AnyValue'
+        json_data:
+          type: string
+          format: binary
         pointerOfString:
           nullable: true
           type: string
@@ -150,8 +153,8 @@ components:
           type: string
         struct:
           $ref: '#/components/schemas/Foo'
-        struct_correct_name:
-          $ref: '#/components/schemas/EditableFoo'
+        test:
+          $ref: '#/components/schemas/Test'
         time:
           type: string
           format: date-time
@@ -159,8 +162,12 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Foo'
+    Test:
+      type: integer
     WeirdCustomName:
       type: object
       properties:
         some_string:
           type: string
+    WeirdInt:
+      type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,53 +1,13 @@
 openapi: 3.0.0
 info:
-  version: ""
-  title: ""
-  description: ""
+  version: 0.0.1
+  title: Some cool title
+  description: Awesome description
 servers: []
 paths:
-  /track/{trackId}:
+  /pets:
     get:
-      summary: Retrieve a track
-      description: Returns a track corresponding to specified id
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Track'
-            application/vnd.geo+json:
-              schema:
-                $ref: '#/components/schemas/Geojson'
-          description: A Track
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-          description: Track not found
-      tags:
-      - track
-      parameters:
-      - in: header
-        name: Accept
-        schema:
-          type: string
-          enum:
-          - application/json
-          - application/vnd.geo+json
-        required: false
-        description: The type of content to be returned, json or geojson
-      - in: path
-        name: trackId
-        schema:
-          type: string
-        required: true
-        description: uuid of the track
-  /tracks/near/{lon}/{lat}:
-    get:
-      summary: Retrieve tracks near a point
-      description: Returns a tracks near a point within a radius of 10km, sorted by
-        proximity
+      description: Returns all pets from the system that the user has access to
       responses:
         "200":
           content:
@@ -55,248 +15,152 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Track'
-            application/vnd.geo+json:
+                  $ref: '#/components/schemas/Pet'
+          description: A list of pets.
+        "302":
+          content: {}
+          description: Trip Signals Redirection
+          headers:
+            Location:
+              description: The url to the signal API
               schema:
-                $ref: '#/components/schemas/Geojson'
-          description: An Array of Tracks
+                type: string
       tags:
-      - track
+      - pet
       parameters:
       - in: path
-        name: lat
+        name: deviceId
         schema:
-          type: string
+          type: integer
+          enum:
+          - "3"
+          - "4"
         required: true
-        description: the latitude of the point
-      - in: path
-        name: lon
-        schema:
-          type: string
+        description: Numeric ID of the user to get
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+    post:
+      description: Returns all pets from the system that the user has access to
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+          description: Post a new pet
+      parameters: []
+      requestBody:
+        description: Pet to add to the store
         required: true
-        description: the longitude of the point
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
 components:
   schemas:
-    Address:
+    AnyValue:
+      description: 'Can be anything: string, number, array, object, etc., including
+        `null`'
+    Dog:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - $ref: '#/components/schemas/WeirdCustomName'
+      - type: object
+        properties:
+          name:
+            type: string
+    EditableFoo:
       type: object
       properties:
-        city:
+        string:
           type: string
-        countryCode:
-          type: string
-        latitude:
-          type: number
-        longitude:
-          type: number
-        position:
-          nullable: true
-          $ref: '#/components/schemas/geojson'
-    Comment:
+    Foo:
       type: object
       properties:
-        content:
+        string:
           type: string
-        creation:
+    MapStringString: null
+    Pet:
+      required:
+      - string
+      type: object
+      properties:
+        ByteData:
           type: string
-          format: date-time
+          format: binary
+        IntData:
+          type: object
+          additionalProperties:
+            type: integer
+        children:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Pet'
+        enumTest:
+          type: string
+          enum:
+          - UNKNOWN
+          - MALE
+          - FEMALE
+        external_data:
+          $ref: '#/components/schemas/WeirdCustomName'
         id:
           type: string
-        modification:
+        int:
+          type: integer
+        interface:
+          $ref: '#/components/schemas/AnyValue'
+        pointerOfString:
+          nullable: true
+          type: string
+        pointerOfStruct:
+          nullable: true
+          $ref: '#/components/schemas/Foo'
+        pointerOfTime:
+          nullable: true
           type: string
           format: date-time
-        user:
-          $ref: '#/components/schemas/User'
-    Elevation:
-      type: array
-      items:
-        type: number
-    NearTrack:
-      type: object
-      properties:
-        Distance:
-          type: number
-        ID:
-          type: string
-    OSMAddress:
-      type: object
-      properties:
-        city:
-          type: string
-        country:
-          type: string
-        country_code:
-          type: string
-        county:
-          type: string
-        hamlet:
-          type: string
-        postcode:
-          type: string
-        public_building:
-          type: string
-        road:
-          type: string
-        state:
-          type: string
-        town:
-          type: string
-        village:
-          type: string
-    OsmPlace:
-      type: object
-      properties:
-        address:
-          $ref: '#/components/schemas/OSMAddress'
-        boundingbox:
+        sliceOfStruct:
+          type: array
+          items:
+            $ref: '#/components/schemas/Foo'
+        sliceofInt:
+          type: array
+          items:
+            type: integer
+        sliceofSliceofFloat:
+          type: array
+          items:
+            items:
+              type: number
+            type: array
+        sliceofString:
           type: array
           items:
             type: string
-        display_name:
+        strData:
+          type: object
+          additionalProperties:
+            type: string
+        string:
           type: string
-        lat:
+        struct:
+          $ref: '#/components/schemas/Foo'
+        struct_correct_name:
+          $ref: '#/components/schemas/EditableFoo'
+        time:
           type: string
-        licence:
-          type: string
-        lon:
-          type: string
-        osm_id:
-          type: string
-        osm_type:
-          type: string
-        place_id:
-          type: string
-    Picture:
+          format: date-time
+    Signals:
+      type: array
+      items:
+        $ref: '#/components/schemas/Foo'
+    WeirdCustomName:
       type: object
       properties:
-        caption:
-          nullable: true
+        some_string:
           type: string
-        creation:
-          type: string
-          format: date-time
-        height:
-          type: integer
-        id:
-          type: string
-        position:
-          nullable: true
-          $ref: '#/components/schemas/geojson'
-        url:
-          type: string
-        width:
-          type: integer
-    Poi:
-      type: object
-      properties:
-        caption:
-          type: string
-        creation:
-          nullable: true
-          type: string
-          format: date-time
-        icon:
-          type: string
-        id:
-          type: string
-        modification:
-          nullable: true
-          type: string
-          format: date-time
-        position:
-          nullable: true
-          $ref: '#/components/schemas/geojson'
-    Rating:
-      type: object
-      additionalProperties: true
-    Track:
-      type: object
-      properties:
-        comments:
-          type: array
-          items:
-            $ref: '#/components/schemas/Comment'
-        creation:
-          type: string
-          format: date-time
-        description:
-          type: string
-        distance:
-          type: integer
-        downloads:
-          type: integer
-        elevationGain:
-          type: integer
-        elevationLoss:
-          type: integer
-        endAddress:
-          nullable: true
-          $ref: '#/components/schemas/Address'
-        id:
-          type: string
-        name:
-          type: string
-        pictures:
-          type: array
-          items:
-            $ref: '#/components/schemas/Picture'
-        pois:
-          type: array
-          items:
-            $ref: '#/components/schemas/Poi'
-        rating:
-          $ref: '#/components/schemas/Rating'
-        startAddress:
-          nullable: true
-          $ref: '#/components/schemas/Address'
-        user:
-          $ref: '#/components/schemas/User'
-        video:
-          type: array
-          items:
-            $ref: '#/components/schemas/Video'
-    User:
-      type: object
-      properties:
-        creation:
-          type: string
-          format: date-time
-        id:
-          type: string
-        modification:
-          nullable: true
-          type: string
-          format: date-time
-        name:
-          type: string
-    Video:
-      type: object
-      properties:
-        creation:
-          nullable: true
-          type: string
-          format: date-time
-        id:
-          nullable: true
-          type: string
-        modification:
-          nullable: true
-          type: string
-          format: date-time
-        platform:
-          nullable: true
-          type: string
-        slug:
-          nullable: true
-          type: string
-        trackId:
-          nullable: true
-          type: string
-    geometry:
-      type: object
-      properties:
-        bbox:
-          type: array
-          items:
-            type: number
-        type:
-          $ref: '#/components/schemas/geojson'


### PR DESCRIPTION
This PR reworks the composition of the `spec` to take into account #30 and #31. 

This allows you to do this:

```golang
// @openapi:schema
type Response struct {
    Data external.MoreData `json:"data"`
}
```
:arrow_down: 
```yaml
Response:
    type: object
    properties:
        data:
            $ref: '#/components/schemas/MoreData'
```

and
```golang
// @openapi:schema:CustomName
type RegularType struct {
 // properties
}

// openapi:schema
type Response {
    Data RegularType `json:"data"`
}
```
:arrow_down: 
```yaml
Response:
    type: object
    properties:
        data:
            $ref: '#/components/schemas/CustomName'
CustomName:
    type: object
    properties:
        # properties
```