### PR TITLE
Rename action to operation and add some missing fields

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -62,7 +62,7 @@ var mergeCmd = &cobra.Command{
 				url := k
 				for verb, action := range v {
 					logrus.WithField("verb", verb).WithField("url", url).Info("Adding Path")
-					main.AddAction(url, verb, action)
+					main.AddOperation(url, verb, action)
 				}
 			}
 

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -14,6 +14,7 @@ import (
 // /pets:
 //	get:
 //		description: "Returns all pets from the system that the user has access to"
+//		operationId: GetUser
 //		tags:
 //			- pet
 //		responses:
@@ -54,6 +55,9 @@ import (
 //                - api         # Production server
 //                - api.dev     # Development server
 //                - api.staging # Staging server
+//		externalDocs:
+//			description: External documentation
+//			url: "https://{environment}-docs.hello.com"
 func GetUser() {}
 
 // PostFoo returns a user corresponding to specified id

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -112,6 +112,11 @@ type composedSchema struct {
 	AllOf    []*schema `yaml:"allOf"`
 }
 
+type externalDoc struct {
+	Description string `yaml:",omitempty"`
+	Url string `yaml:"url,omitempty"`
+}
+
 func (c *composedSchema) RealName() string {
 	if c == nil {
 		return ""
@@ -183,23 +188,22 @@ func (e BuildError) Error() string {
 	return err
 }
 
-type items struct {
-	Type string
-}
+// /pets: operation
+type path map[string]operation
 
-// /pets: action
-type path map[string]action
-
-type action struct {
+type operation struct {
 	Summary     string `yaml:",omitempty"`
 	Description string
+	ID          string `yaml:"operationId,omitempty"`
 	Responses   map[string]response
 	Tags        []string `yaml:",omitempty"`
 	Parameters  []parameter
 	RequestBody requestBody           `yaml:"requestBody,omitempty"`
 	Security    []map[string][]string `yaml:",omitempty"`
 	Headers     map[string]header     `yaml:",omitempty"`
+	Deprecated  bool				  `yaml:",omitempty"`
 	Servers     []server              `yaml:",omitempty"`
+	ExternalDocs externalDoc		  `yaml:"externalDocs,omitempty"`
 }
 
 type parameter struct {
@@ -323,7 +327,7 @@ func (spec *openAPI) parsePaths(f *ast.File) (errors []error) {
 			if _, ok := spec.Paths[url]; ok {
 				// Iterate over verbs
 				for currentVerb, currentDesc := range path {
-					if _, actionAlreadyExists := spec.Paths[url][currentVerb]; actionAlreadyExists {
+					if _, operationAlreadyExists := spec.Paths[url][currentVerb]; operationAlreadyExists {
 						logrus.
 							WithField("url", url).
 							WithField("verb", currentVerb).
@@ -571,9 +575,9 @@ func (spec *openAPI) parseSchemas(f *ast.File) (errors []error) {
 	return
 }
 
-func (spec *openAPI) AddAction(path, verb string, a action) {
+func (spec *openAPI) AddOperation(path, verb string, a operation) {
 	if _, ok := spec.Paths[path]; !ok {
-		spec.Paths[path] = make(map[string]action)
+		spec.Paths[path] = make(map[string]operation)
 	}
 	spec.Paths[path][verb] = a
 }

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -114,7 +114,7 @@ type composedSchema struct {
 
 type externalDoc struct {
 	Description string `yaml:",omitempty"`
-	Url string `yaml:"url,omitempty"`
+	Url         string `yaml:"url,omitempty"`
 }
 
 func (c *composedSchema) RealName() string {
@@ -192,18 +192,18 @@ func (e BuildError) Error() string {
 type path map[string]operation
 
 type operation struct {
-	Summary     string `yaml:",omitempty"`
-	Description string
-	ID          string `yaml:"operationId,omitempty"`
-	Responses   map[string]response
-	Tags        []string `yaml:",omitempty"`
-	Parameters  []parameter
-	RequestBody requestBody           `yaml:"requestBody,omitempty"`
-	Security    []map[string][]string `yaml:",omitempty"`
-	Headers     map[string]header     `yaml:",omitempty"`
-	Deprecated  bool				  `yaml:",omitempty"`
-	Servers     []server              `yaml:",omitempty"`
-	ExternalDocs externalDoc		  `yaml:"externalDocs,omitempty"`
+	Summary      string `yaml:",omitempty"`
+	Description  string
+	ID           string `yaml:"operationId,omitempty"`
+	Responses    map[string]response
+	Tags         []string `yaml:",omitempty"`
+	Parameters   []parameter
+	RequestBody  requestBody           `yaml:"requestBody,omitempty"`
+	Security     []map[string][]string `yaml:",omitempty"`
+	Headers      map[string]header     `yaml:",omitempty"`
+	Deprecated   bool                  `yaml:",omitempty"`
+	Servers      []server              `yaml:",omitempty"`
+	ExternalDocs externalDoc           `yaml:"externalDocs,omitempty"`
 }
 
 type parameter struct {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,7 +16,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Pet"
+                  $ref: '#/components/schemas/Pet'
           description: A list of pets.
         "302":
           content: {}
@@ -27,32 +27,32 @@ paths:
               schema:
                 type: string
       tags:
-        - pet
+      - pet
       parameters:
-        - in: path
-          name: deviceId
-          schema:
-            type: integer
-            enum:
-              - "3"
-              - "4"
-          required: true
-          description: Numeric ID of the user to get
+      - in: path
+        name: deviceId
+        schema:
+          type: integer
+          enum:
+          - "3"
+          - "4"
+        required: true
+        description: Numeric ID of the user to get
       security:
-        - petstore_auth:
-            - write:pets
-            - read:pets
+      - petstore_auth:
+        - write:pets
+        - read:pets
       servers:
-        - url: https://{environment}.hello.com
-          description: what up
-          variables:
-            environment:
-              default: api
-              enum:
-                - api
-                - api.dev
-                - api.staging
-              description: ""
+      - url: https://{environment}.hello.com
+        description: what up
+        variables:
+          environment:
+            default: api
+            enum:
+            - api
+            - api.dev
+            - api.staging
+            description: ""
       externalDocs:
         description: External documentation
         url: https://{environment}-docs.hello.com
@@ -65,7 +65,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/Pet"
+                  $ref: '#/components/schemas/Pet'
           description: Post a new pet
       parameters: []
       requestBody:
@@ -74,7 +74,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Pet"
+              $ref: '#/components/schemas/Pet'
 components:
   schemas:
     AnonymousArray:
@@ -88,19 +88,18 @@ components:
                 type: string
             type: object
     AnyValue:
-      description:
-        "Can be anything: string, number, array, object, etc., including
-        `null`"
+      description: 'Can be anything: string, number, array, object, etc., including
+        `null`'
     CustomString:
       type: string
     Dog:
       allOf:
-        - $ref: "#/components/schemas/Pet"
-        - $ref: "#/components/schemas/WeirdCustomName"
-        - type: object
-          properties:
-            name:
-              type: string
+      - $ref: '#/components/schemas/Pet'
+      - $ref: '#/components/schemas/WeirdCustomName'
+      - type: object
+        properties:
+          name:
+            type: string
     EditableFoo:
       type: object
       properties:
@@ -114,7 +113,7 @@ components:
     MapStringString: null
     Pet:
       required:
-        - string
+      - string
       type: object
       properties:
         ByteData:
@@ -132,15 +131,15 @@ components:
         children:
           type: object
           additionalProperties:
-            $ref: "#/components/schemas/Pet"
+            $ref: '#/components/schemas/Pet'
         custom_string:
-          $ref: "#/components/schemas/CustomString"
+          $ref: '#/components/schemas/CustomString'
         enumTest:
           type: string
           enum:
-            - UNKNOWN
-            - MALE
-            - FEMALE
+          - UNKNOWN
+          - MALE
+          - FEMALE
         id:
           type: string
         int:
@@ -153,7 +152,7 @@ components:
           type: string
         pointerOfStruct:
           nullable: true
-          $ref: "#/components/schemas/Foo"
+          $ref: '#/components/schemas/Foo'
         pointerOfTime:
           nullable: true
           type: string
@@ -161,7 +160,7 @@ components:
         sliceOfStruct:
           type: array
           items:
-            $ref: "#/components/schemas/Foo"
+            $ref: '#/components/schemas/Foo'
         sliceofInt:
           type: array
           items:
@@ -183,16 +182,16 @@ components:
         string:
           type: string
         struct:
-          $ref: "#/components/schemas/Foo"
+          $ref: '#/components/schemas/Foo'
         test:
-          $ref: "#/components/schemas/Test"
+          $ref: '#/components/schemas/Test'
         time:
           type: string
           format: date-time
     Signals:
       type: array
       items:
-        $ref: "#/components/schemas/Foo"
+        $ref: '#/components/schemas/Foo'
     Test:
       type: integer
     WeirdCustomName:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,6 +8,7 @@ paths:
   /pets:
     get:
       description: Returns all pets from the system that the user has access to
+      operationId: GetUser
       responses:
         "200":
           content:
@@ -41,6 +42,20 @@ paths:
       - petstore_auth:
         - write:pets
         - read:pets
+      servers:
+      - url: https://{environment}.hello.com
+        description: what up
+        variables:
+          environment:
+            default: api
+            enum:
+            - api
+            - api.dev
+            - api.staging
+            description: ""
+      externalDocs:
+        description: External documentation
+        url: https://{environment}-docs.hello.com
     post:
       description: Returns all pets from the system that the user has access to
       responses:
@@ -171,3 +186,4 @@ components:
           type: string
     WeirdInt:
       type: integer
+x-tagGroups: []


### PR DESCRIPTION
As specified in the following ticket: https://github.com/alexjomin/openapi-parser/issues/4, operationId are currently not supported.

This PR aims at filling that gap, allowing the generated OpenAPI spec to be used to generate better SDKs (as it stands, the name of the methods are quite hard to digest).

I also added deprecated and externalDocs, but did not add Callback as I could not think of a good way to do it just yet. The spec itself seems to support different formats for the callbacks.

It is worth mentioning that with this implementation, deprecated will only appear if true.