### PR TITLE
feat: adds anonymous struct support

### DIFF
--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -110,6 +110,17 @@ type Pet struct {
 	JSONData            json.RawMessage           `json:"json_data"`
 	CustomString        otherpackage.CustomString `json:"custom_string"`
 	Test                Test                      `json:"test"`
+	Anonymous           struct {
+		Field string `json:"field"`
+	} `json:"anonymous"`
+}
+
+// AnonymousArray struct
+// @openapi:schema
+type AnonymousArray struct {
+	Data []struct {
+		ID string `json:"id"`
+	} `json:"data"`
 }
 
 // Dog struct

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -83,6 +83,7 @@ func PostFoo() {}
 // @openapi:schema
 type MapStringString map[string]string
 
+// WeirdInt type
 // @openapi:schema
 type WeirdInt int
 

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -451,12 +451,11 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 			if j.ignore {
 				continue
 			}
-			p, err := parseNamedType(f, fld.Type, nil)
-
 			if j.required {
 				e.Required = append(e.Required, j.name)
 			}
 
+			p, err := parseNamedType(f, fld.Type, nil)
 			if err != nil {
 				logrus.WithError(err).WithField("field", fld.Names[0]).Error("Can't parse the type of field in struct")
 				errors = append(errors, BuildError{

--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -98,11 +98,18 @@ func parseNamedType(gofile *ast.File, expr ast.Expr, sel *ast.Ident) (*schema, e
 		p.Format = format
 		return &p, nil
 	case *ast.StarExpr: // pointer to something, optional by default
-		t, _ := parseNamedType(gofile, ftpe.X, nil)
+		t, err := parseNamedType(gofile, ftpe.X, nil)
+		if err != nil {
+			return nil, err
+		}
 		t.Nullable = true
 		return t, nil
 	case *ast.ArrayType: // slice type
-		cp, _ := parseNamedType(gofile, ftpe.Elt, nil)
+		cp, err := parseNamedType(gofile, ftpe.Elt, nil)
+		if err != nil {
+			return nil, err
+		}
+
 		if cp.Format == "binary" {
 			p.Type = "string"
 			p.Format = "binary"
@@ -123,7 +130,11 @@ func parseNamedType(gofile *ast.File, expr ast.Expr, sel *ast.Ident) (*schema, e
 	case *ast.StructType:
 		return nil, fmt.Errorf("expr (%s) not yet unsupported", expr)
 	case *ast.SelectorExpr:
-		t, _ := parseNamedType(gofile, ftpe.X, ftpe.Sel)
+		t, err := parseNamedType(gofile, ftpe.X, ftpe.Sel)
+		if err != nil {
+			return nil, err
+		}
+
 		return t, nil
 	case *ast.MapType:
 		k, kerr := parseNamedType(gofile, ftpe.Key, nil)

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -139,9 +139,51 @@ func TestParseNamedType(t *testing.T) {
 			}},
 		},
 		{
-			description:   "Should throw error when parse *ast.StructType",
-			expr:          &ast.StructType{},
-			expectedError: "expr (&{%!s(token.Pos=0) %!s(*ast.FieldList=<nil>) %!s(bool=false)}) not yet unsupported",
+			description: "Should *ast.ArrayType with *ast.StructType",
+			expr: &ast.ArrayType{
+				Elt: &ast.StructType{
+					Fields: &ast.FieldList{
+						List: []*ast.Field{
+							{
+								Type: &ast.Ident{Name: "string"},
+								Tag:  &ast.BasicLit{Value: "`json:\"str\"`"},
+							},
+						},
+					},
+				},
+			},
+			expectedSchema: &schema{
+				Type: "array",
+				Items: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]*schema{
+						"str": {
+							Type: "string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Should *ast.StructType to anonymous struct",
+			expr: &ast.StructType{
+				Fields: &ast.FieldList{
+					List: []*ast.Field{
+						{
+							Type: &ast.Ident{Name: "string"},
+							Tag:  &ast.BasicLit{Value: "`json:\"str\"`"},
+						},
+					},
+				},
+			},
+			expectedSchema: &schema{
+				Type: "object",
+				Properties: map[string]*schema{
+					"str": {
+						Type: "string",
+					},
+				},
+			},
 		},
 		{
 			description: "Should throw error when parse *ast.MapType[nil]nil",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -41,6 +41,17 @@ paths:
       - petstore_auth:
         - write:pets
         - read:pets
+      servers:
+      - url: https://{environment}.hello.com
+        description: what up
+        variables:
+          environment:
+            default: api
+            enum:
+            - api
+            - api.dev
+            - api.staging
+            description: ""
     post:
       description: Returns all pets from the system that the user has access to
       responses:
@@ -62,6 +73,16 @@ paths:
               $ref: '#/components/schemas/Pet'
 components:
   schemas:
+    AnonymousArray:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            properties:
+              id:
+                type: string
+            type: object
     AnyValue:
       description: 'Can be anything: string, number, array, object, etc., including
         `null`'
@@ -98,6 +119,11 @@ components:
           type: object
           additionalProperties:
             type: integer
+        anonymous:
+          type: object
+          properties:
+            field:
+              type: string
         children:
           type: object
           additionalProperties:
@@ -171,3 +197,4 @@ components:
           type: string
     WeirdInt:
       type: integer
+x-tagGroups: []


### PR DESCRIPTION
This PR aims to add support for anonymous structs like this:

```go
// @openapi:schema
type RealStruct struct {
    Anonymous struct {
	Field string `json:"field"`
    } `json:"anonymous"`
}
```

Or

```go
// AnonymousArray struct
// @openapi:schema
type AnonymousArray struct {
	Data []struct {
		ID string `json:"id"`
	} `json:"data"`
}
```

This PR also adds a bunch of error handling where missing

Closes #37 