### PR TITLE
fix: ref objects cannot have nullable property

### DIFF
--- a/docparser/model.go
+++ b/docparser/model.go
@@ -141,7 +141,7 @@ func (c *composedSchema) SetCustomName(customName string) {
 
 type schema struct {
 	metadata             `yaml:"-"`
-	Nullable             bool                   `yaml:"nullable,omitempty"`
+	Nullable             *bool                  `yaml:"nullable,omitempty"`
 	Required             []string               `yaml:"required,omitempty"`
 	Type                 string                 `yaml:",omitempty"`
 	Items                map[string]interface{} `yaml:",omitempty"`

--- a/docparser/parser.go
+++ b/docparser/parser.go
@@ -102,7 +102,11 @@ func parseNamedType(gofile *ast.File, expr ast.Expr, sel *ast.Ident) (*schema, e
 		if err != nil {
 			return nil, err
 		}
-		t.Nullable = true
+		if t.Ref == "" {
+			// if ref, cannot have other properties
+			tBool := true
+			t.Nullable = &tBool
+		}
 		return t, nil
 	case *ast.ArrayType: // slice type
 		cp, err := parseNamedType(gofile, ftpe.Elt, sel)

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -82,6 +82,7 @@ func TestParseFile(t *testing.T) {
 }
 
 func TestParseNamedType(t *testing.T) {
+	tBool := true
 	testCases := []parseNamedTypeTestCase{
 		{
 			description:    "Should parse *ast.Ident with unknown name",
@@ -107,7 +108,7 @@ func TestParseNamedType(t *testing.T) {
 		{
 			description:    "Should parse *ast.StarExpr and set Nullable",
 			expr:           &ast.StarExpr{X: &ast.Ident{Name: "time"}},
-			expectedSchema: &schema{Type: "string", Format: "date-time", Nullable: true},
+			expectedSchema: &schema{Type: "string", Format: "date-time", Nullable: &tBool},
 		},
 		{
 			description: "Should parse *ast.ArrayType with known type",


### PR DESCRIPTION
The change of bool to *bool is because when bool is false, with the omitempty tag, the field was not present.