### PR TITLE
Feat/handle slice aliases

### DIFF
--- a/docparser/model.go
+++ b/docparser/model.go
@@ -374,14 +374,23 @@ func replaceSchemaNameToCustom(s *schema) {
 	if len(refSplit) != 4 {
 		return
 	}
+
 	if replacementSchema, found := registeredSchemas[refSplit[3]]; found {
-		meta, ok := replacementSchema.(metaSchema)
+		meta, ok := replacementSchema.(*schema)
 		if !ok {
 			return
 		}
-		refSplit[3] = meta.CustomName()
+		switch meta.Type {
+		case "array":
+			s.Ref = meta.Ref
+			s.Items = meta.Items
+			s.Type = meta.Type
+			break
+		default:
+			refSplit[3] = meta.CustomName()
+			s.Ref = strings.Join(refSplit, "/")
+		}
 	}
-	s.Ref = strings.Join(refSplit, "/")
 }
 
 func (spec *openAPI) composeSpecSchemas() {

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -468,7 +468,7 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 				e.Required = append(e.Required, j.name)
 			}
 
-			p, err := parseNamedType(f, fld.Type, nil)
+			p, err := parseNamedType(fld.Type, nil)
 			if err != nil {
 				logrus.WithError(err).WithField("field", fld.Names[0]).Error("Can't parse the type of field in struct")
 				errors = append(errors, BuildError{
@@ -495,7 +495,7 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 				}
 			}
 
-			p, err := parseNamedType(f, fld.Type, nil)
+			p, err := parseNamedType(fld.Type, nil)
 			if err != nil {
 				logrus.WithError(err).WithField("field", fld.Type).Error("Can't parse the type of composed field in struct")
 				errors = append(errors, BuildError{
@@ -576,7 +576,7 @@ func (spec *openAPI) parseSchemas(f *ast.File) (errors []error) {
 
 				case *ast.ArrayType:
 					e := newEntity()
-					p, err := parseNamedType(f, n.Elt, nil)
+					p, err := parseNamedType(n.Elt, nil)
 					if err != nil {
 						logrus.WithError(err).Error("Can't parse the type of field in struct")
 						errors = append(errors, &BuildError{
@@ -595,7 +595,7 @@ func (spec *openAPI) parseSchemas(f *ast.File) (errors []error) {
 					entity = &e
 
 				default:
-					p, err := parseNamedType(f, ts.Type, nil)
+					p, err := parseNamedType(ts.Type, nil)
 					if err != nil {
 						logrus.WithError(err).Error("can't parse custom type")
 						errors = append(errors, BuildError{

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -140,32 +140,6 @@ func TestParseNamedType(t *testing.T) {
 			}},
 		},
 		{
-			description: "Should *ast.ArrayType with *ast.StructType",
-			expr: &ast.ArrayType{
-				Elt: &ast.StructType{
-					Fields: &ast.FieldList{
-						List: []*ast.Field{
-							{
-								Type: &ast.Ident{Name: "string"},
-								Tag:  &ast.BasicLit{Value: "`json:\"str\"`"},
-							},
-						},
-					},
-				},
-			},
-			expectedSchema: &schema{
-				Type: "array",
-				Items: map[string]interface{}{
-					"type": "object",
-					"properties": map[string]*schema{
-						"str": {
-							Type: "string",
-						},
-					},
-				},
-			},
-		},
-		{
 			description: "Should *ast.StructType to anonymous struct",
 			expr: &ast.StructType{
 				Fields: &ast.FieldList{
@@ -279,7 +253,7 @@ func TestParseNamedType(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			schema, err := parseNamedType(tc.gofile, tc.expr, nil)
+			schema, err := parseNamedType(tc.expr, nil)
 			if len(tc.expectedError) > 0 {
 				if (err != nil) && (err.Error() != tc.expectedError) {
 					t.Errorf("got error: %v, wantErr: %v", err, tc.expectedError)

--- a/docparser/parser_test.go
+++ b/docparser/parser_test.go
@@ -250,6 +250,32 @@ func TestParseNamedType(t *testing.T) {
 			expr:          &ast.FuncType{},
 			expectedError: "expr (&{%!s(token.Pos=0) %!s(*ast.FieldList=<nil>) %!s(*ast.FieldList=<nil>)}) type (&{%!s(token.Pos=0) %!s(*ast.FieldList=<nil>) %!s(*ast.FieldList=<nil>)}) is unsupported for a schema",
 		},
+		{
+			description: "Should *ast.ArrayType with *ast.StructType",
+			expr: &ast.ArrayType{
+				Elt: &ast.StructType{
+					Fields: &ast.FieldList{
+						List: []*ast.Field{
+							{
+								Type: &ast.Ident{Name: "string"},
+								Tag:  &ast.BasicLit{Value: "`json:\"str\"`"},
+							},
+						},
+					},
+				},
+			},
+			expectedSchema: &schema{
+				Type: "array",
+				Items: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]*schema{
+						"str": {
+							Type: "string",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
Hi guys,

There was a small "regression" (might not have been planned to work before anyway) following commit 2d9c7efd9323134eaeba37dc1003a41fc81b55ee.

What it changed is that now when using aliases for slices, the ref will not be properly filled. Here is a small example, related to the following code:

```go
// Signal
// @openapi:schema
type Signal struct {
    id string `json:"id,omitempty"`
}

// Signals
// @openapi:schema
type Signals []Signal

// AliasesSlice
// @openapi:schema
type AliasesSlice struct {
    Signals signals
}
```

What it did before:

```yaml
components:
  schemas:
    AliasesSlice:
      type: object
      properties:
        signals:
          $ref: '#/components/schemas/Signals'
    Signals:
      type: array
      items:
        $ref: '#/components/schemas/Signal'
```

What it does now:

```yaml
components:
  schemas:
    AliasesSlice:
      type: object
      properties:
        signals:
          $ref: '#/components/schemas/'
    Signals:
      type: array
      items:
        $ref: '#/components/schemas/Signal'
```

My changes attempt to fix that, even going a bit further by replacing the alias by the actual struct

What my changes does:

```yaml
components:
  schemas:
    AliasesSlice:
      type: object
      properties:
        signals:
          type: array
          items:
            $ref: '#/components/schemas/Signal'
    Signals:
      type: array
      items:
        $ref: '#/components/schemas/Foo'
```

I admit I would go further and remove the Signals schema altogether from the generated documentation but wanted your thoughts on the whole thing before moving further.

@Sadzeih ? @denouche ?

Thanks in advance