### PR TITLE
Implement new tag @openapi:example

### DIFF
--- a/docparser/convert.go
+++ b/docparser/convert.go
@@ -1,0 +1,42 @@
+package docparser
+
+import (
+	"fmt"
+	"go/ast"
+	"strconv"
+)
+
+func convertExample(example string, exampleType ast.Expr) (interface{}, error) {
+	expr, ok := exampleType.(*ast.Ident)
+	if !ok {
+		return example, nil
+	}
+
+	switch expr.Name {
+	case "int", "int8", "int32", "int64":
+		i, err := strconv.ParseInt(example, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse int: %w", err)
+		}
+		return i, nil
+
+	case "uint", "uint8", "uint32", "uint64":
+		u, err := strconv.ParseUint(example, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse uint: %w", err)
+		}
+
+		return u, nil
+
+	case "float", "float32", "float64":
+		f, err := strconv.ParseFloat(example, 64)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse float: %w", err)
+		}
+
+		return f, nil
+
+	default:
+		return example, nil
+	}
+}

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -94,7 +94,8 @@ type WeirdInt int
 // Pet struct
 // @openapi:schema
 type Pet struct {
-	ID                  bson.ObjectId             `json:"id"`
+	// @openapi:example f1dad44f-600a-4fe3-8ae1-fdc35f99bdb0
+	ID                  bson.ObjectId             `json:"id"` // test
 	String              string                    `json:"string,omitempty" validate:"required"`
 	Int                 int                       `json:"int,omitempty"`
 	PointerOfString     *string                   `json:"pointerOfString"`

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -96,7 +96,8 @@ type WeirdInt int
 // @openapi:schema
 type Pet struct {
 	// @openapi:example f1dad44f-600a-4fe3-8ae1-fdc35f99bdb0
-	ID                  bson.ObjectId             `json:"id"` // test
+	ID bson.ObjectId `json:"id"` // test
+	// @openapi:example Some String Example
 	String              string                    `json:"string,omitempty" validate:"required"`
 	Int                 int                       `json:"int,omitempty"`
 	WeirdInt            WeirdInt                  `json:"weird_int,omitempty"`

--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -89,6 +89,7 @@ type MapStringString map[string]string
 
 // WeirdInt type
 // @openapi:schema
+// @openapi:example 42
 type WeirdInt int
 
 // Pet struct
@@ -98,6 +99,7 @@ type Pet struct {
 	ID                  bson.ObjectId             `json:"id"` // test
 	String              string                    `json:"string,omitempty" validate:"required"`
 	Int                 int                       `json:"int,omitempty"`
+	WeirdInt            WeirdInt                  `json:"weird_int,omitempty"`
 	PointerOfString     *string                   `json:"pointerOfString"`
 	SliceOfString       []string                  `json:"sliceofString"`
 	SliceOfInt          []int                     `json:"sliceofInt"`

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -531,9 +531,9 @@ func (spec *openAPI) parseExample(comment string, exampleType ast.Expr) (interfa
 	}
 
 	line := string(exampleLines[0])
-	lineSplit := strings.Split(line, " ")
+	example := line[len("@openapi:example "):]
 
-	return convertExample(lineSplit[1], exampleType)
+	return convertExample(example, exampleType)
 }
 
 func (spec *openAPI) parseSchemas(f *ast.File) (errors []error) {

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -14,10 +14,11 @@ import (
 )
 
 var (
-	regexpPath   = regexp.MustCompile("@openapi:path\n([^@]*)$")
-	rexexpSchema = regexp.MustCompile(`@openapi:schema:?(\w+)?:?(?:\[([\w,]+)\])?`)
-	regexpInfo   = regexp.MustCompile("@openapi:info\n([^@]*)$")
-	tab          = regexp.MustCompile(`\t`)
+	regexpPath    = regexp.MustCompile("@openapi:path\n([^@]*)$")
+	regexpSchema  = regexp.MustCompile(`@openapi:schema:?(\w+)?:?(?:\[([\w,]+)\])?`)
+	regexpExample = regexp.MustCompile(`@openapi:example [^\v\n]+`)
+	regexpInfo    = regexp.MustCompile("@openapi:info\n([^@]*)$")
+	tab           = regexp.MustCompile(`\t`)
 
 	registeredSchemas = map[string]interface{}{
 		"AnyValue": map[string]string{
@@ -151,6 +152,7 @@ type schema struct {
 	Properties           map[string]*schema     `yaml:",omitempty"`
 	AdditionalProperties *schema                `yaml:"additionalProperties,omitempty"`
 	OneOf                []schema               `yaml:"oneOf,omitempty"`
+	Example              string             `yaml:"example,omitempty"`
 }
 
 func (s *schema) RealName() string {
@@ -450,6 +452,9 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 	e.Type = "object"
 
 	for _, fld := range tpe.Fields.List {
+
+		example, _ := spec.parseExample(fld)
+
 		if len(fld.Names) > 0 && fld.Names[0] != nil && fld.Names[0].IsExported() {
 			j, err := parseJSONTag(fld)
 			if j.ignore {
@@ -468,6 +473,10 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 					Message: "can't parse the type of field in struct",
 				})
 				continue
+			}
+
+			if example != nil {
+				p.Example = *example
 			}
 
 			if len(j.enum) > 0 {
@@ -496,6 +505,10 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 				continue
 			}
 
+			if example != nil {
+				p.Example = *example
+			}
+
 			cs.AllOf = append(cs.AllOf, p)
 		}
 	}
@@ -506,6 +519,20 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 		cs.AllOf = append(cs.AllOf, &e)
 		return cs, errors
 	}
+}
+
+func (spec *openAPI) parseExample(f *ast.Field) (*string, error) {
+	fd := f.Doc.Text()
+
+	exampleLines := regexpExample.FindSubmatch([]byte(fd))
+	if len(exampleLines) == 0 {
+		return nil, nil
+	}
+
+	line := string(exampleLines[0])
+	lineSplit := strings.Split(line, " ")
+
+	return &lineSplit[1], nil
 }
 
 func (spec *openAPI) parseSchemas(f *ast.File) (errors []error) {
@@ -526,7 +553,7 @@ func (spec *openAPI) parseSchemas(f *ast.File) (errors []error) {
 				entityName := realName
 
 				// Looking for openapi entity
-				a := rexexpSchema.FindSubmatch([]byte(t))
+				a := regexpSchema.FindSubmatch([]byte(t))
 
 				if len(a) == 0 {
 					continue

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -168,9 +168,9 @@ components:
         sliceofSliceofFloat:
           type: array
           items:
-            type: array
             items:
               type: number
+            type: array
         sliceofString:
           type: array
           items:
@@ -188,6 +188,8 @@ components:
         time:
           type: string
           format: date-time
+        weird_int:
+          $ref: '#/components/schemas/WeirdInt'
     Signals:
       type: array
       items:
@@ -201,4 +203,5 @@ components:
           type: string
     WeirdInt:
       type: integer
+      example: 42
 x-tagGroups: []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -181,6 +181,7 @@ components:
             type: string
         string:
           type: string
+          example: Some String Example
         struct:
           $ref: '#/components/schemas/Foo'
         test:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -142,6 +142,7 @@ components:
           - FEMALE
         id:
           type: string
+          example: f1dad44f-600a-4fe3-8ae1-fdc35f99bdb0
         int:
           type: integer
         json_data:
@@ -151,7 +152,6 @@ components:
           nullable: true
           type: string
         pointerOfStruct:
-          nullable: true
           $ref: '#/components/schemas/Foo'
         pointerOfTime:
           nullable: true
@@ -168,9 +168,9 @@ components:
         sliceofSliceofFloat:
           type: array
           items:
+            type: array
             items:
               type: number
-            type: array
         sliceofString:
           type: array
           items:


### PR DESCRIPTION
This PR implements a `@openapi:example` tag for examples.

### Usage:

```golang
// @openapi:schema
type Character struct {
    // @openapi:example Nathan Drake
    Name string `json:"name"` // putting the tag here won't work
}

// @openapi:schema
// @openapi:example 42
type Age int
```
will result in:

```yaml
Character:
  type: object
  properties:
    name:
      type: string
      example: Nathan Drake
Age:
  type: integer
  example: 42
```

### Notes

The conversion only handles `float` types, `int` and `uint` types. Otherwise, it stays as a string.
