### PR TITLE
fix: don't parse non-exported fields in structs

### DIFF
--- a/docparser/datatest/user.go
+++ b/docparser/datatest/user.go
@@ -127,13 +127,21 @@ type AnonymousArray struct {
 	} `json:"data"`
 }
 
+// @openapi:schema
+type animal struct {
+	species string
+}
+
 // Dog struct
 // @openapi:schema
 type Dog struct {
 	Pet
+	animal
 	otherpackage.Data
 
-	Name string `json:"name"`
+	Name    string `json:"name"`
+	weight  int
+	friends []animal
 }
 
 // Foo struct

--- a/docparser/model.go
+++ b/docparser/model.go
@@ -450,6 +450,9 @@ func (spec *openAPI) parseStructs(f *ast.File, tpe *ast.StructType) (interface{}
 	e.Type = "object"
 
 	for _, fld := range tpe.Fields.List {
+		if len(fld.Names) > 0 && fld.Names[0] != nil && !fld.Names[0].IsExported() {
+			continue
+		}
 		if len(fld.Names) > 0 && fld.Names[0] != nil && fld.Names[0].IsExported() {
 			j, err := parseJSONTag(fld)
 			if j.ignore {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -95,6 +95,7 @@ components:
     Dog:
       allOf:
       - $ref: '#/components/schemas/Pet'
+      - $ref: '#/components/schemas/animal'
       - $ref: '#/components/schemas/WeirdCustomName'
       - type: object
         properties:
@@ -151,7 +152,6 @@ components:
           nullable: true
           type: string
         pointerOfStruct:
-          nullable: true
           $ref: '#/components/schemas/Foo'
         pointerOfTime:
           nullable: true
@@ -201,4 +201,6 @@ components:
           type: string
     WeirdInt:
       type: integer
+    animal:
+      type: object
 x-tagGroups: []


### PR DESCRIPTION
This fixes a bug where having private fields would add them to the struct as "composed" fields.

This fixes the issue by not adding private fields.

### Example

```go
// @openapi:schema
type animal struct {
	species string
}

// Dog struct
// @openapi:schema
type Dog struct {
	Pet
	animal
	otherpackage.Data

	Name    string `json:"name"`
	weight  int
	friends []animal
}
```

:arrow_down: 

```yaml
    Dog:
      allOf:
      - $ref: '#/components/schemas/Pet'
      - $ref: '#/components/schemas/animal'
      - $ref: '#/components/schemas/WeirdCustomName'
      - type: object
        properties:
          name:
            type: string
    animal:
      type: object
```

