### PR TITLE
feat: add import feature to load markdown in description

### DIFF
--- a/docparser/model_test.go
+++ b/docparser/model_test.go
@@ -157,3 +157,44 @@ func TestParseInfos(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseImportContentPath(t *testing.T) {
+	type args struct {
+		str string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test correct string",
+			args: args{
+				"import(readme.md)",
+			},
+			want:    "readme.md",
+			wantErr: false,
+		},
+		{
+			name: "test not an import file",
+			args: args{
+				"some random content for the test",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseImportContentPath(tt.args.str)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseImportContentPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseImportContentPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hey!

In order to avoid a huge API description right in the code, this PR is about adding an import feature to load the content of a markdown file.

This feature allows backward compatibility.

Example
```
// @openapi:info
// version: 0.0.1
// title: Awesome API
// description: import(README.md)
```

The resulting openapi specifications will contain the content of the README.md as a description. 

Thanks in advance for the review!